### PR TITLE
[144] Include data registration numbers when searching repository

### DIFF
--- a/spec/unit/repositories/company_record_repository_spec.rb
+++ b/spec/unit/repositories/company_record_repository_spec.rb
@@ -97,11 +97,54 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
       {
         query: {
           bool: {
-            must: [
+            should: [
               {
                 match: {
                   company_number: {
-                    query: company_record.company_number,
+                    query: "1234567",
+                  },
+                },
+              },
+              {
+                match: {
+                  company_number: {
+                    query: "01234567",
+                  },
+                },
+              },
+              {
+                nested: {
+                  path: "data.identification",
+                  query: {
+                    bool: {
+                      must: [
+                        {
+                          match: {
+                            'data.identification.registration_number': {
+                              query: "1234567",
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                nested: {
+                  path: "data.identification",
+                  query: {
+                    bool: {
+                      must: [
+                        {
+                          match: {
+                            'data.identification.registration_number': {
+                              query: "01234567",
+                            },
+                          },
+                        },
+                      ],
+                    },
                   },
                 },
               },


### PR DESCRIPTION
When searching for company_numbers, it should:
- look at ones with leading zeros
- return any which matches registration_number