### PR TITLE
Added build query option for searching raw records

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop
+rubocop -A
 
 echo -e "\n=== RSpec"
 rspec

--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop -A
+rubocop
 
 echo -e "\n=== RSpec"
 rspec

--- a/lib/register_sources_psc/repositories/company_record_repository.rb
+++ b/lib/register_sources_psc/repositories/company_record_repository.rb
@@ -150,8 +150,8 @@ module RegisterSourcesPsc
             must: [
               {
                 term: {
-                  _index: index,
-                },
+                  _index: index
+                }
               },
               {
                 bool: {
@@ -201,11 +201,11 @@ module RegisterSourcesPsc
                         ]
                       }
                     }
-                  end,
-                },
-              },
-            ],
-          },
+                  end
+                }
+              }
+            ]
+          }
         }
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -228,7 +228,7 @@ module RegisterSourcesPsc
         SearchResults.new(
           mapped.sort_by(&:score).reverse,
           total_count:,
-          aggs: results['aggregations'],
+          aggs: results['aggregations']
         )
       end
 

--- a/lib/register_sources_psc/repositories/company_record_repository.rb
+++ b/lib/register_sources_psc/repositories/company_record_repository.rb
@@ -3,6 +3,8 @@
 require_relative '../config/elasticsearch'
 require_relative '../structs/company_record'
 
+BodsIdentifier = Struct.new(:id, :schemeName)
+
 module RegisterSourcesPsc
   module Repositories
     class CompanyRecordRepository
@@ -200,10 +202,10 @@ module RegisterSourcesPsc
                       }
                     }
                   end,
-                }
-              }
-            ]
-          }
+                },
+              },
+            ],
+          },
         }
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/integration/company_record_repository_spec.rb
+++ b/spec/integration/company_record_repository_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
       expect(subject.get(corporate_record.data.etag)).to eq corporate_record
 
       # When records do not exist
-      expect(subject.get("missing")).to be_nil
-      expect(subject.list_by_company_number("missing")).to eq []
+      expect(subject.get('missing')).to be_nil
+      expect(subject.list_by_company_number('missing')).to eq []
     end
   end
 end

--- a/spec/integration/company_record_repository_spec.rb
+++ b/spec/integration/company_record_repository_spec.rb
@@ -87,15 +87,8 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
       expect(subject.get(corporate_record.data.etag)).to eq corporate_record
 
       # When records do not exist
-      expect(subject.get('missing')).to be_nil
-      expect(subject.list_by_company_number('missing')).to eq []
-
-      # get identifiers
-      identifiers = [
-        OpenStruct.new(id: corporate_record.data.links[:self], # rubocop:disable Style/OpenStructUse
-                       schemeName: 'GB Persons Of Significant Control Register')
-      ]
-      expect(subject.get_by_bods_identifiers(identifiers)).to eq [corporate_record]
+      expect(subject.get("missing")).to be_nil
+      expect(subject.list_by_company_number("missing")).to eq []
     end
   end
 end

--- a/spec/unit/repositories/company_record_repository_spec.rb
+++ b/spec/unit/repositories/company_record_repository_spec.rb
@@ -2,6 +2,8 @@
 
 require 'register_sources_psc/repositories/company_record_repository'
 
+BodsIdentifier = Struct.new(:id, :schemeName)
+
 RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
   subject { described_class.new(client:, index:) }
 
@@ -221,4 +223,58 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
       end
     end
   end
+
+  # rubocop:disable RSpec/ExampleLength
+  describe '#build_get_by_bods_identifiers' do
+    it 'builds query for searching by bods identifiers' do
+      identifiers = [
+        BodsIdentifier.new('12345', 'GB Persons Of Significant Control Register'),
+      ]
+
+      query = subject.build_get_by_bods_identifiers(identifiers)
+
+      expect(query).to eq(
+        bool: {
+          must: [
+            {
+              term: {
+                _index: index,
+              },
+            },
+            {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must: [
+                        {
+                          nested: {
+                            path: "data.links",
+                            query: {
+                              bool: {
+                                must: [
+                                  {
+                                    match: {
+                                      'data.links.self': {
+                                        query: "12345",
+                                      },
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      )
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/unit/repositories/company_record_repository_spec.rb
+++ b/spec/unit/repositories/company_record_repository_spec.rb
@@ -224,11 +224,10 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
     end
   end
 
-  # rubocop:disable RSpec/ExampleLength
   describe '#build_get_by_bods_identifiers' do
     it 'builds query for searching by bods identifiers' do
       identifiers = [
-        BodsIdentifier.new('12345', 'GB Persons Of Significant Control Register'),
+        BodsIdentifier.new('12345', 'GB Persons Of Significant Control Register')
       ]
 
       query = subject.build_get_by_bods_identifiers(identifiers)
@@ -238,8 +237,8 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
           must: [
             {
               term: {
-                _index: index,
-              },
+                _index: index
+              }
             },
             {
               bool: {
@@ -249,32 +248,31 @@ RSpec.describe RegisterSourcesPsc::Repositories::CompanyRecordRepository do
                       must: [
                         {
                           nested: {
-                            path: "data.links",
+                            path: 'data.links',
                             query: {
                               bool: {
                                 must: [
                                   {
                                     match: {
                                       'data.links.self': {
-                                        query: "12345",
-                                      },
-                                    },
-                                  },
-                                ],
-                              },
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
+                                        query: '12345'
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
       )
     end
   end
-  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
The Register needs to be able to combine and submit the queries as a single query over multiple indexes, to properly paginate raw record requests over multiple sources.

To allow this, the query for raw records is now built and returned instead of being performed inside the repository.