### PR TITLE
[#188] fix dry-types warning for mutable []

### DIFF
--- a/lib/register_sources_psc/structs/legal_person.rb
+++ b/lib/register_sources_psc/structs/legal_person.rb
@@ -18,7 +18,7 @@ module RegisterSourcesPsc
     attribute? :kind,               LegalPersonKinds
     attribute? :links,              Links
     attribute? :name,               Types::String
-    attribute? :natures_of_control, Types.Array(Descriptions).default([])
+    attribute? :natures_of_control, Types.Array(Descriptions).default([].freeze)
     attribute? :notified_on,        Types::Nominal::Date
   end
 end

--- a/lib/register_sources_psc/structs/legal_person_beneficial_owner.rb
+++ b/lib/register_sources_psc/structs/legal_person_beneficial_owner.rb
@@ -19,7 +19,7 @@ module RegisterSourcesPsc
     attribute? :kind,                     LegalPersonBeneficialOwnerKinds
     attribute? :links,                    Links
     attribute? :name,                     Types::String
-    attribute? :natures_of_control,       Types.Array(Descriptions).default([])
+    attribute? :natures_of_control,       Types.Array(Descriptions).default([].freeze)
     attribute? :notified_on,              Types::Nominal::Date
     attribute? :principal_office_address, Address
   end


### PR DESCRIPTION
    [dry-types] [] is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
    /home/x/lib/register-sources-psc/lib/register_sources_psc/structs/legal_person.rb:21:in `<class:LegalPerson>'
    [dry-types] [] is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
    /home/x/lib/register-sources-psc/lib/register_sources_psc/structs/legal_person_beneficial_owner.rb:22:in `<class:LegalPersonBeneficialOwner>'

---

References https://github.com/openownership/register/issues/188 .