### PR TITLE
[#188] fix Repositories::RegisteredOverseasRecordRepository initialize

### DIFF
--- a/lib/register_sources_psc/repositories/registered_overseas_record_repository.rb
+++ b/lib/register_sources_psc/repositories/registered_overseas_record_repository.rb
@@ -8,7 +8,7 @@ module RegisterSourcesPsc
   module Repositories
     class RegisteredOverseasRecordRepository < CompanyRecordRepository
       def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ELASTICSEARCH_INDEX_OVERSEAS)
-        super(client, index)
+        super(client:, index:)
       end
     end
   end


### PR DESCRIPTION
This was broken in 67b32260f736b2768e51a6bbe8481422473ec00b during the refactor.

---

References https://github.com/openownership/register/issues/188 .